### PR TITLE
error handling

### DIFF
--- a/website/client/src/components/wp-matchmaker.vue
+++ b/website/client/src/components/wp-matchmaker.vue
@@ -58,6 +58,10 @@
 
                           <div class="col">
                             <button type="button" class="btn btn-custom btn-block" @click=createGame>Create Game</button>
+                                <!-- Error Message Display -->
+                                <div v-if="errorMsg" class="alert alert-danger">
+                                {{ errorMsg }}
+                                </div>
                           </div>
 
                           <div class="col">
@@ -101,7 +105,8 @@
                     // {creatorName: "kev", game_id: "test"}
                 ],
                 icoPlayerVS: faUserCircle,
-                icoCloseModal: faTimes
+                icoCloseModal: faTimes,
+                errorMsg: null,
             }
         },
         computed: {
@@ -161,6 +166,8 @@
                     }, 
                     error => {
                         console.log('Game creation failed => ' + error)
+                        // Update errorMsg so it gets displayed in the UI
+                        this.errorMsg = 'Game creation failed => ' + error + "\n Please try again later";
                     }
                 )
             },

--- a/website/client/src/main.js
+++ b/website/client/src/main.js
@@ -32,10 +32,12 @@ Vue.use(BootstrapVue)
 Vue.use(IconsPlugin)
 Vue.use(Flicking)
 
-Vue.config.errorHandler = function (err, vm, info) {
-  alert('Err: ' + err + ', info: ' + info)
+Vue.config.errorHandler = function (err) { //vm, info parameters removed
+  // alert('Err: ' + err + ', info: ' + info)
+  alert("Something went wrong. Open a new instance of Varcade Games in a new tab")
   console.error('Error! Message: ', err.message)
   console.error('Exception thrown', err.stack)
+  
 }
 
 window.onerror = function (message, source, lineno, colno, error) {


### PR DESCRIPTION
I detected a problem creating a multiplayer game regardless if the game server works or not. For example, a user would select multiplayer, create a game, and successfully enter the select a character scene. If a user decides to go back to the home screen, tries to play Rock Paper Scissors and creates a game from multiplayer again, "alert('Err: ' + err + ', info: ' + info)" is prompted from line 36 in the main.js file, in website/client/src. A way around it was to just open up a new instance of Varcade Games in a new tab, so I updated the error message to say that. 